### PR TITLE
refactor grpc client context handling and examples

### DIFF
--- a/config/examples/grpc_insecure_example.yaml
+++ b/config/examples/grpc_insecure_example.yaml
@@ -11,13 +11,13 @@ output:
     address: 127.0.0.1:50051
     method: /ingest.Ingest/Stream
     
-    # TLS removed in this example set; using insecure transport for local testing
+    # Example using insecure transport for local testing
     proto_files: [ "ingest.proto", "google/protobuf/struct.proto" ]
     include_paths: [ "cmd/tools/grpc_test_server/pb" ]
     
     # Connection settings
     authority: ""
-    user_agent: bento-secure-client/1.0
+    user_agent: bento-insecure-client/1.0
     load_balancing_policy: pick_first
     
     # Timeouts and limits
@@ -47,6 +47,6 @@ output:
     
     # Request metadata
     default_metadata:
-      client-type: bento-secure
+      client-type: bento-insecure
       environment: local
       trace-enabled: "true"

--- a/internal/impl/grpc_client/common.go
+++ b/internal/impl/grpc_client/common.go
@@ -489,13 +489,6 @@ func (h headerCreds) RequireTransportSecurity() bool {
 	return h.tlsEnabled
 }
 
-// context key for connection manager
-type ctxKey int
-
-const (
-	ctxKeyConnMgr ctxKey = iota
-)
-
 // ConnectionPool manages a pool of gRPC connections for performance optimization.
 //
 // The pool implements a round-robin connection selection strategy with automatic
@@ -507,23 +500,9 @@ const (
 //
 // Lifecycle: Connections are created during pool initialization and replaced
 // when they become idle beyond the configured timeout.
-type ConnectionPool struct {
-	connections []connectionEntry // Pool of gRPC connections
-	mu          sync.RWMutex      // Protects concurrent access to pool state
-	cfg         *Config           // Configuration for connection management
-	nextIndex   int               // Round-robin index for connection selection
-	closed      bool              // Indicates if pool is closed
-}
-
-// connectionEntry represents a single gRPC connection in the pool with metadata
-type connectionEntry struct {
-	conn          *grpc.ClientConn // The actual gRPC connection
-	lastUsed      time.Time        // Timestamp of last usage for idle cleanup
-	createdAt     time.Time        // When this connection was created
-	failureCount  int              // Number of consecutive failures
-	lastFailure   time.Time        // Time of last failure
-	healthChecked time.Time        // Last time health was checked
-}
+//
+// NOTE: ConnectionPool has been moved to connection_pool.go to keep this file focused
+// on shared helpers and configuration.
 
 // CircuitBreakerState represents the state of the circuit breaker
 type CircuitBreakerState int
@@ -688,6 +667,7 @@ func NewConnectionManager(ctx context.Context, cfg *Config) (*ConnectionManager,
 	pool := &ConnectionPool{
 		connections: make([]connectionEntry, 0, cfg.MaxConnectionPoolSize),
 		cfg:         cfg,
+		ctx:         ctx,
 	}
 
 	// Create circuit breaker with configurable thresholds
@@ -774,86 +754,6 @@ func createConnection(ctx context.Context, cfg *Config) (*grpc.ClientConn, error
 	}
 
 	return conn, nil
-}
-
-// isConnectionHealthy validates the connection state and health
-func isConnectionHealthy(conn *grpc.ClientConn) bool {
-	if conn == nil {
-		return false
-	}
-
-	// Check connection state
-	state := conn.GetState()
-	switch state {
-	case connectivity.Ready:
-		return true
-	case connectivity.Idle:
-		// Idle connections are acceptable, they can be activated
-		return true
-	case connectivity.Connecting:
-		// Connecting state might be temporary, give it a chance
-		return true
-	case connectivity.TransientFailure:
-		// Transient failures should trigger replacement
-		return false
-	case connectivity.Shutdown:
-		// Shutdown connections are definitely unusable
-		return false
-	default:
-		// Unknown state, be conservative
-		return false
-	}
-}
-
-// isConnectionHealthyWithHistory validates connection health considering failure history
-// isConnectionHealthyWithHistory was unused; removed to satisfy staticcheck (U1000)
-
-// recordConnectionFailure records a failure for the connection entry with enhanced tracking
-func recordConnectionFailure(entry *connectionEntry) {
-	if entry == nil {
-		return
-	}
-
-	now := time.Now()
-	entry.failureCount++
-	entry.lastFailure = now
-
-	// Logging handled at higher levels if needed
-}
-
-// recordConnectionSuccess resets failure count for successful connections
-func recordConnectionSuccess(entry *connectionEntry) {
-	if entry == nil {
-		return
-	}
-
-	// Only reset if we had failures before
-	if entry.failureCount > 0 {
-		// Log recovery for monitoring
-		// Logger not available in this scope
-		entry.failureCount = 0
-		entry.lastFailure = time.Time{}
-	}
-}
-
-// isConnectionExcessivelyFailing checks if a connection has failed too many times recently
-func isConnectionExcessivelyFailing(entry *connectionEntry, maxFailures int, failureWindow time.Duration) bool {
-	if entry == nil {
-		return true
-	}
-
-	// Check failure count threshold
-	if entry.failureCount >= maxFailures {
-		// Check if failures are within the failure window
-		if time.Since(entry.lastFailure) <= failureWindow {
-			return true
-		}
-		// Reset failure count if outside the window (connection has recovered)
-		entry.failureCount = 0
-		entry.lastFailure = time.Time{}
-	}
-
-	return false
 }
 
 // GetConnection returns an available gRPC connection from the pool (thread-safe)
@@ -973,105 +873,6 @@ func (cm *ConnectionManager) GetConnectionStats() map[string]interface{} {
 	return stats
 }
 
-// getConnection gets an available connection from the pool with state validation
-func (cp *ConnectionPool) getConnection() (*grpc.ClientConn, error) {
-	cp.mu.Lock()
-	defer cp.mu.Unlock()
-
-	if cp.closed {
-		return nil, errors.New("connection pool is closed")
-	}
-
-	// First pass: Try to find a healthy connection in round-robin order
-	for i := 0; i < len(cp.connections); i++ {
-		idx := (cp.nextIndex + i) % len(cp.connections)
-		entry := &cp.connections[idx]
-
-		if !isConnectionExcessivelyFailing(entry, defaultMaxConnectionFailures, defaultFailureWindow) {
-			// Validate connection health
-			if !isConnectionHealthy(entry.conn) {
-				recordConnectionFailure(entry)
-				// Try to replace unhealthy connection
-				if newConn, err := createConnection(context.Background(), cp.cfg); err == nil {
-					entry.conn.Close()
-					now := time.Now()
-					entry.conn = newConn
-					entry.lastUsed = now
-					entry.createdAt = now
-					entry.failureCount = 0
-					entry.lastFailure = time.Time{}
-					entry.healthChecked = now
-				} else {
-					// Skip this connection and try next one
-					continue
-				}
-			}
-
-			entry.lastUsed = time.Now()
-			entry.healthChecked = time.Now()
-			cp.nextIndex = (idx + 1) % len(cp.connections)
-
-			// Record successful connection usage
-			recordConnectionSuccess(entry)
-
-			return entry.conn, nil
-		}
-	}
-
-	// Second pass: Find the best available connection (prioritize by failure rate)
-	var bestEntry *connectionEntry
-	var bestScore = -1
-
-	for i, entry := range cp.connections {
-		// Calculate connection score (lower is better)
-		score := entry.failureCount
-
-		// Boost score for recently failed connections (within last minute)
-		if time.Since(entry.lastFailure) < time.Minute {
-			score += 10
-		}
-
-		// Prefer connections that haven't been used recently (for load balancing)
-		if time.Since(entry.lastUsed) > time.Minute {
-			score -= 5
-		}
-
-		if bestEntry == nil || score < bestScore {
-			bestEntry = &cp.connections[i]
-			bestScore = score
-		}
-	}
-
-	if bestEntry != nil {
-		// Validate the best connection before returning it
-		if !isConnectionHealthy(bestEntry.conn) {
-			recordConnectionFailure(bestEntry)
-			// Try to replace unhealthy connection
-			if newConn, err := createConnection(context.Background(), cp.cfg); err == nil {
-				bestEntry.conn.Close()
-				now := time.Now()
-				bestEntry.conn = newConn
-				bestEntry.lastUsed = now
-				bestEntry.createdAt = now
-				bestEntry.failureCount = 0
-				bestEntry.lastFailure = time.Time{}
-				bestEntry.healthChecked = now
-			}
-			// Continue using the connection even if replacement failed
-		}
-
-		bestEntry.lastUsed = time.Now()
-		bestEntry.healthChecked = time.Now()
-
-		// Record successful connection usage
-		recordConnectionSuccess(bestEntry)
-
-		return bestEntry.conn, nil
-	}
-
-	return nil, errors.New("no connections available in pool")
-}
-
 // cleanupIdleConnections periodically cleans up idle connections
 func (cm *ConnectionManager) cleanupIdleConnections() {
 	interval := defaultCleanupTickerInterval
@@ -1090,88 +891,6 @@ func (cm *ConnectionManager) cleanupIdleConnections() {
 		cm.mu.RUnlock()
 
 		cm.pool.cleanupIdle()
-	}
-}
-
-// cleanupIdle removes connections that have been idle for too long or are unhealthy with comprehensive monitoring
-func (cp *ConnectionPool) cleanupIdle() {
-	cp.mu.Lock()
-	defer cp.mu.Unlock()
-
-	if cp.closed {
-		return
-	}
-
-	now := time.Now()
-	replacedCount := 0
-	failedCleanupCount := 0
-
-	for i := range cp.connections {
-		entry := &cp.connections[i]
-		shouldReplace := false
-
-		// Check for idle timeout
-		if now.Sub(entry.lastUsed) > cp.cfg.ConnectionIdleTimeout {
-			shouldReplace = true
-		}
-
-		// Check for excessive failures
-		if isConnectionExcessivelyFailing(entry, defaultMaxConnectionFailures, defaultFailureWindow) {
-			shouldReplace = true
-		}
-
-		// Perform periodic health checks
-		interval := cp.cfg.ConnectionHealthcheckInterval
-		if interval <= 0 {
-			interval = defaultHealthCheckInterval
-		}
-		if now.Sub(entry.healthChecked) > interval {
-			if !isConnectionHealthy(entry.conn) {
-				recordConnectionFailure(entry)
-				shouldReplace = true
-			} else {
-				entry.healthChecked = now
-				recordConnectionSuccess(entry)
-			}
-		}
-
-		// Check for connections that are too old
-		if cp.cfg.ConnectionMaxLifetime > 0 && now.Sub(entry.createdAt) > cp.cfg.ConnectionMaxLifetime {
-			shouldReplace = true
-		}
-
-		if shouldReplace {
-			// Close the connection and create a new one
-			if entry.conn != nil {
-				entry.conn.Close()
-			}
-
-			if newConn, err := createConnection(context.Background(), cp.cfg); err == nil {
-				entry.conn = newConn
-				entry.lastUsed = now
-				entry.createdAt = now
-				entry.failureCount = 0
-				entry.lastFailure = time.Time{}
-				entry.healthChecked = now
-				replacedCount++
-
-				// Replacement succeeded
-			} else {
-				failedCleanupCount++
-				// Keep old connection; next health check will try again
-			}
-		}
-	}
-
-	// Optional: surface metrics via stats instead of logs
-}
-
-// closeAllConnections closes all connections in the pool
-func (cp *ConnectionPool) closeAllConnections() {
-	for _, entry := range cp.connections {
-		if entry.conn != nil {
-			entry.conn.Close()
-		}
 	}
 }
 

--- a/internal/impl/grpc_client/connection_pool.go
+++ b/internal/impl/grpc_client/connection_pool.go
@@ -1,0 +1,281 @@
+package grpc_client
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
+)
+
+// ConnectionPool manages a pool of gRPC connections for performance optimization.
+//
+// The pool implements a round-robin connection selection strategy with automatic
+// connection release. Connections are marked as "in use" temporarily to prevent
+// concurrent access conflicts, then automatically released after a short delay.
+//
+// Thread Safety: All public methods are thread-safe using RWMutex protection.
+// The pool supports concurrent access from multiple goroutines.
+//
+// Lifecycle: Connections are created during pool initialization and replaced
+// when they become idle beyond the configured timeout.
+type ConnectionPool struct {
+	connections []connectionEntry // Pool of gRPC connections
+	mu          sync.RWMutex      // Protects concurrent access to pool state
+	cfg         *Config           // Configuration for connection management
+	nextIndex   int               // Round-robin index for connection selection
+	closed      bool              // Indicates if pool is closed
+	ctx         context.Context   // Parent context for new connections
+}
+
+// connectionEntry represents a single gRPC connection in the pool with metadata
+type connectionEntry struct {
+	conn          *grpc.ClientConn // The actual gRPC connection
+	lastUsed      time.Time        // Timestamp of last usage for idle cleanup
+	createdAt     time.Time        // When this connection was created
+	failureCount  int              // Number of consecutive failures
+	lastFailure   time.Time        // Time of last failure
+	healthChecked time.Time        // Last time health was checked
+}
+
+// getConnection gets an available connection from the pool with state validation
+func (cp *ConnectionPool) getConnection() (*grpc.ClientConn, error) {
+	cp.mu.Lock()
+	defer cp.mu.Unlock()
+
+	if cp.closed {
+		return nil, errors.New("connection pool is closed")
+	}
+
+	// First pass: Try to find a healthy connection in round-robin order
+	for i := 0; i < len(cp.connections); i++ {
+		idx := (cp.nextIndex + i) % len(cp.connections)
+		entry := &cp.connections[idx]
+
+		if !isConnectionExcessivelyFailing(entry, defaultMaxConnectionFailures, defaultFailureWindow) {
+			// Validate connection health
+			if !isConnectionHealthy(entry.conn) {
+				recordConnectionFailure(entry)
+				// Try to replace unhealthy connection
+				if newConn, err := createConnection(cp.ctx, cp.cfg); err == nil {
+					entry.conn.Close()
+					now := time.Now()
+					entry.conn = newConn
+					entry.lastUsed = now
+					entry.createdAt = now
+					entry.failureCount = 0
+					entry.lastFailure = time.Time{}
+					entry.healthChecked = now
+				} else {
+					// Skip this connection and try next one
+					continue
+				}
+			}
+
+			entry.lastUsed = time.Now()
+			entry.healthChecked = time.Now()
+			cp.nextIndex = (idx + 1) % len(cp.connections)
+
+			// Record successful connection usage
+			recordConnectionSuccess(entry)
+
+			return entry.conn, nil
+		}
+	}
+
+	// Second pass: Find the best available connection (prioritize by failure rate)
+	var bestEntry *connectionEntry
+	var bestScore = -1
+
+	for i, entry := range cp.connections {
+		// Calculate connection score (lower is better)
+		score := entry.failureCount
+
+		// Boost score for recently failed connections (within last minute)
+		if time.Since(entry.lastFailure) < time.Minute {
+			score += 10
+		}
+
+		// Prefer connections that haven't been used recently (for load balancing)
+		if time.Since(entry.lastUsed) > time.Minute {
+			score -= 5
+		}
+
+		if bestEntry == nil || score < bestScore {
+			bestEntry = &cp.connections[i]
+			bestScore = score
+		}
+	}
+
+	if bestEntry != nil {
+		// Validate the best connection before returning it
+		if !isConnectionHealthy(bestEntry.conn) {
+			recordConnectionFailure(bestEntry)
+			// Try to replace unhealthy connection
+			if newConn, err := createConnection(cp.ctx, cp.cfg); err == nil {
+				bestEntry.conn.Close()
+				now := time.Now()
+				bestEntry.conn = newConn
+				bestEntry.lastUsed = now
+				bestEntry.createdAt = now
+				bestEntry.failureCount = 0
+				bestEntry.lastFailure = time.Time{}
+				bestEntry.healthChecked = now
+			}
+			// Continue using the connection even if replacement failed
+		}
+
+		bestEntry.lastUsed = time.Now()
+		bestEntry.healthChecked = time.Now()
+
+		// Record successful connection usage
+		recordConnectionSuccess(bestEntry)
+
+		return bestEntry.conn, nil
+	}
+
+	return nil, errors.New("no connections available in pool")
+}
+
+// cleanupIdle removes connections that have been idle for too long or are unhealthy
+func (cp *ConnectionPool) cleanupIdle() {
+	cp.mu.Lock()
+	defer cp.mu.Unlock()
+
+	if cp.closed {
+		return
+	}
+
+	now := time.Now()
+
+	for i := range cp.connections {
+		entry := &cp.connections[i]
+		shouldReplace := false
+
+		// Check for idle timeout
+		if now.Sub(entry.lastUsed) > cp.cfg.ConnectionIdleTimeout {
+			shouldReplace = true
+		}
+
+		// Check for excessive failures
+		if isConnectionExcessivelyFailing(entry, defaultMaxConnectionFailures, defaultFailureWindow) {
+			shouldReplace = true
+		}
+
+		// Perform periodic health checks
+		interval := cp.cfg.ConnectionHealthcheckInterval
+		if interval <= 0 {
+			interval = defaultHealthCheckInterval
+		}
+		if now.Sub(entry.healthChecked) > interval {
+			if !isConnectionHealthy(entry.conn) {
+				recordConnectionFailure(entry)
+				shouldReplace = true
+			} else {
+				entry.healthChecked = now
+				recordConnectionSuccess(entry)
+			}
+		}
+
+		// Check for connections that are too old
+		if cp.cfg.ConnectionMaxLifetime > 0 && now.Sub(entry.createdAt) > cp.cfg.ConnectionMaxLifetime {
+			shouldReplace = true
+		}
+
+		if shouldReplace {
+			if entry.conn != nil {
+				entry.conn.Close()
+			}
+
+			if newConn, err := createConnection(cp.ctx, cp.cfg); err == nil {
+				entry.conn = newConn
+				entry.lastUsed = now
+				entry.createdAt = now
+				entry.failureCount = 0
+				entry.lastFailure = time.Time{}
+				entry.healthChecked = now
+			} else if cp.cfg.Logger != nil {
+				cp.cfg.Logger.With("address", cp.cfg.Address).Debugf("failed to refresh idle connection: %v", err)
+			}
+		}
+	}
+}
+
+// closeAllConnections closes all connections in the pool
+func (cp *ConnectionPool) closeAllConnections() {
+	cp.mu.Lock()
+	defer cp.mu.Unlock()
+
+	for _, entry := range cp.connections {
+		if entry.conn != nil {
+			entry.conn.Close()
+		}
+	}
+	cp.connections = nil
+	cp.closed = true
+}
+
+// isConnectionHealthy validates the connection state and health
+func isConnectionHealthy(conn *grpc.ClientConn) bool {
+	if conn == nil {
+		return false
+	}
+
+	state := conn.GetState()
+	switch state {
+	case connectivity.Ready:
+		return true
+	case connectivity.Idle:
+		return true
+	case connectivity.Connecting:
+		return true
+	case connectivity.TransientFailure:
+		return false
+	case connectivity.Shutdown:
+		return false
+	default:
+		return false
+	}
+}
+
+// recordConnectionFailure records a failure for the connection entry with enhanced tracking
+func recordConnectionFailure(entry *connectionEntry) {
+	if entry == nil {
+		return
+	}
+
+	now := time.Now()
+	entry.failureCount++
+	entry.lastFailure = now
+}
+
+// recordConnectionSuccess resets failure count for successful connections
+func recordConnectionSuccess(entry *connectionEntry) {
+	if entry == nil {
+		return
+	}
+
+	if entry.failureCount > 0 {
+		entry.failureCount = 0
+		entry.lastFailure = time.Time{}
+	}
+}
+
+// isConnectionExcessivelyFailing checks if a connection has failed too many times recently
+func isConnectionExcessivelyFailing(entry *connectionEntry, maxFailures int, failureWindow time.Duration) bool {
+	if entry == nil {
+		return true
+	}
+
+	if entry.failureCount >= maxFailures {
+		if time.Since(entry.lastFailure) <= failureWindow {
+			return true
+		}
+		entry.failureCount = 0
+		entry.lastFailure = time.Time{}
+	}
+
+	return false
+}

--- a/internal/impl/grpc_client/input_grpc_client.go
+++ b/internal/impl/grpc_client/input_grpc_client.go
@@ -169,7 +169,6 @@ func (g *genericInput) handleUnaryCall(ctx context.Context, requestMsg *dynamic.
 
 	// Enhanced context handling with proper deadline propagation
 	callCtx := g.enhanceCallContext(ctx)
-	callCtx = context.WithValue(callCtx, ctxKeyConnMgr, g.connMgr)
 	var cancel context.CancelFunc
 
 	if g.cfg.CallTimeout > 0 {
@@ -287,7 +286,6 @@ func (g *genericInput) openStreamLocked(ctx context.Context, requestMsg *dynamic
 
 	// Enhanced context handling for server streaming
 	streamCtx := g.enhanceCallContext(ctx)
-	streamCtx = context.WithValue(streamCtx, ctxKeyConnMgr, g.connMgr)
 	var cancel context.CancelFunc
 
 	if g.cfg.CallTimeout > 0 {

--- a/internal/impl/grpc_client/output_grpc_client.go
+++ b/internal/impl/grpc_client/output_grpc_client.go
@@ -459,7 +459,6 @@ func (u *UnifiedOutput) handleUnaryWrite(ctx context.Context, requestMsg *dynami
 
 	// Enhanced context handling with proper deadline propagation
 	callCtx := u.enhanceCallContext(ctx)
-	callCtx = context.WithValue(callCtx, ctxKeyConnMgr, u.connMgr)
 	var cancel context.CancelFunc
 
 	if u.cfg.CallTimeout > 0 {
@@ -593,7 +592,6 @@ func (u *UnifiedOutput) createClientStreamSession(ctx context.Context, sessionKe
 
 	// Enhanced context handling for streaming
 	streamCtx := u.enhanceCallContext(ctx)
-	streamCtx = context.WithValue(streamCtx, ctxKeyConnMgr, u.connMgr)
 	var cancel context.CancelFunc
 
 	if u.cfg.CallTimeout > 0 {
@@ -626,7 +624,6 @@ func (u *UnifiedOutput) createBidiStreamSession(ctx context.Context, sessionKey 
 
 	// Enhanced context handling for bidirectional streaming
 	streamCtx := u.enhanceCallContext(ctx)
-	streamCtx = context.WithValue(streamCtx, ctxKeyConnMgr, u.connMgr)
 	var cancel context.CancelFunc
 
 	if u.cfg.CallTimeout > 0 {


### PR DESCRIPTION
## Summary
- remove unused grpc client context baggage
- propagate parent context and manage connection pool in new module
- rename insecure grpc example

## Testing
- `go test ./internal/impl/grpc_client -run TestInput_injectMetadataIntoContext -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68bae79c7ee8832bba43b03b6782f0b6